### PR TITLE
add .dng file type support

### DIFF
--- a/imagedecoder.raw/addon.xml.in
+++ b/imagedecoder.raw/addon.xml.in
@@ -10,8 +10,8 @@
   <extension
     point="kodi.imagedecoder"
     library_@PLATFORM@="@LIBRARY_FILENAME@"
-    extension=".cr2|.nef|.arw"
-    mimetype="image/cr2|image/nef|image/arw"/>
+    extension=".dng|.cr2|.nef|.arw"
+    mimetype="image/dng|image/cr2|image/nef|image/arw"/>
   <extension point="xbmc.addon.metadata">
     <summary>libraw based image decoder</summary>
     <description>libraw based image decoder</description>


### PR DESCRIPTION
following up #2 

I'm not sure what to do about the depends build (if anything)

This was tested in LibreELEC with libraw built with dng support.