### PR TITLE
[cmake] FindRAW: fix find_library for all platforms

### DIFF
--- a/FindRAW.cmake
+++ b/FindRAW.cmake
@@ -11,7 +11,7 @@ if(PKG_CONFIG_FOUND)
 endif()
 
 find_path(RAW_INCLUDE_DIRS NAMES libraw.h PATHS ${PC_RAW_INCLUDEDIR} PATH_SUFFIXES libraw)
-find_library(RAW_LIBRARIES NAMES libraw_r libraw PATHS ${PC_RAW_LIBDIR})
+find_library(RAW_LIBRARIES NAMES raw_r raw libraw PATHS ${PC_RAW_LIBDIR})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(RAW DEFAULT_MSG RAW_INCLUDE_DIRS RAW_LIBRARIES)


### PR DESCRIPTION
this fixes #12, tested for Windows (32 & 64 bit), Linux, OSX, iOS and Android
#9 (and maybe #4) introduced the build failure.