### PR TITLE
[depends][common] libraw: autoreconf to fix potential automake version mismatch

### DIFF
--- a/depends/common/libraw/CMakeLists.txt
+++ b/depends/common/libraw/CMakeLists.txt
@@ -6,6 +6,7 @@ include(ExternalProject)
 
 externalproject_add(libraw
   SOURCE_DIR ${CMAKE_SOURCE_DIR}
+  UPDATE_COMMAND autoreconf -vif
   CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} AR=${CMAKE_AR} ${CMAKE_SOURCE_DIR}/configure --disable-examples --prefix=${OUTPUT_DIR}
   INSTALL_COMMAND ""
   BUILD_IN_SOURCE 1)


### PR DESCRIPTION
needed because I bumped automake in kodi depends (from 1.15 to 1.15.1) and now building this addon gives the following error
```
configure.ac:3: error: version mismatch.  This is Automake 1.15.1,
configure.ac:3: but the definition used by this AM_INIT_AUTOMAKE
configure.ac:3: comes from Automake 1.15.  You should recreate
configure.ac:3: aclocal.m4 with aclocal and run automake again.
```