### PR TITLE
Fix libraw Windows patches

### DIFF
--- a/depends/windows/libraw/0002-fix-uwp-api.patch
+++ b/depends/windows/libraw/0002-fix-uwp-api.patch
@@ -1,27 +1,27 @@
 --- a/src/libraw_datastream.cpp
 +++ b/src/libraw_datastream.cpp
-@@ -687,6 +687,27 @@
+@@ -644,6 +644,27 @@ void *LibRaw_bigfile_datastream::make_jas_stream()
  // == LibRaw_windows_datastream
- #ifdef WIN32
+ #ifdef LIBRAW_WIN32_CALLS
  
 +#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
 +// For Unicode platforms, TCHAR is defined as synonymous with the WCHAR type.
 +HANDLE WINAPI CreateFile(LPCWSTR lpFileName,
-+                          DWORD dwDesiredAccess,
-+                          DWORD dwShareMode,
-+                          LPSECURITY_ATTRIBUTES lpSecurityAttributes,
-+                          DWORD dwCreationDisposition,
-+                          DWORD dwFlagsAndAttributes,
-+                          HANDLE hTemplateFile)
++                         DWORD dwDesiredAccess,
++                         DWORD dwShareMode,
++                         LPSECURITY_ATTRIBUTES lpSecurityAttributes,
++                         DWORD dwCreationDisposition,
++                         DWORD dwFlagsAndAttributes,
++                         HANDLE hTemplateFile)
 +{
-+    CREATEFILE2_EXTENDED_PARAMETERS createExParams;
-+    createExParams.dwSize = sizeof(CREATEFILE2_EXTENDED_PARAMETERS);
-+    createExParams.dwFileAttributes = dwFlagsAndAttributes & 0xFFFF;
-+    createExParams.dwFileFlags = dwFlagsAndAttributes & 0xFFF00000;
-+    createExParams.dwSecurityQosFlags = dwFlagsAndAttributes & 0x000F00000;
-+    createExParams.lpSecurityAttributes = lpSecurityAttributes;
-+    createExParams.hTemplateFile = hTemplateFile;
-+    return CreateFile2(lpFileName, dwDesiredAccess, dwShareMode, dwCreationDisposition, &createExParams);
++  CREATEFILE2_EXTENDED_PARAMETERS createExParams;
++  createExParams.dwSize = sizeof(CREATEFILE2_EXTENDED_PARAMETERS);
++  createExParams.dwFileAttributes = dwFlagsAndAttributes & 0xFFFF;
++  createExParams.dwFileFlags = dwFlagsAndAttributes & 0xFFF00000;
++  createExParams.dwSecurityQosFlags = dwFlagsAndAttributes & 0x000F00000;
++  createExParams.lpSecurityAttributes = lpSecurityAttributes;
++  createExParams.hTemplateFile = hTemplateFile;
++  return CreateFile2(lpFileName, dwDesiredAccess, dwShareMode, dwCreationDisposition, &createExParams);
 +}
 +#endif
 +

--- a/depends/windows/libraw/0003-fix-sdl-errors.patch
+++ b/depends/windows/libraw/0003-fix-sdl-errors.patch
@@ -1,6 +1,6 @@
 --- a/src/decoders/crx.cpp
 +++ b/src/decoders/crx.cpp
-@@ -347,7 +347,7 @@
+@@ -347,7 +347,7 @@ libraw_inline void crxDecodeSymbolL1(CrxBandParam *param,
                (bitCode << param->kParam);
  
    // add converted (+/-) error code to predicted value
@@ -9,7 +9,7 @@
  
    // for not end of the line - use one symbol ahead to estimate next K
    if (notEOL)
-@@ -456,7 +456,7 @@
+@@ -456,7 +456,7 @@ libraw_inline void crxDecodeSymbolL1Rounded(CrxBandParam *param,
    else if (param->kParam)
      bitCode = crxBitstreamGetBits(&param->bitStream, param->kParam) |
                (bitCode << param->kParam);
@@ -18,7 +18,7 @@
    param->lineBuf1[1] = param->roundedBitsMask * 2 * code + (code >> 31) + sym;
  
    if (doCode)
-@@ -576,7 +576,7 @@
+@@ -576,7 +576,7 @@ int crxDecodeLineNoRefPrevLine(CrxBandParam *param)
        else if (param->kParam)
          bitCode = crxBitstreamGetBits(&param->bitStream, param->kParam) |
                    (bitCode << param->kParam);
@@ -27,7 +27,7 @@
        param->kParam = crxPredictKParameter(param->kParam, bitCode);
        if (param->lineBuf2[i + 1] - param->kParam <= 1)
        {
-@@ -638,7 +638,7 @@
+@@ -638,7 +638,7 @@ int crxDecodeLineNoRefPrevLine(CrxBandParam *param)
            else if (param->kParam)
              bitCode = crxBitstreamGetBits(&param->bitStream, param->kParam) |
                        (bitCode << param->kParam);
@@ -36,7 +36,7 @@
            param->kParam = crxPredictKParameter(param->kParam, bitCode, 15);
            param->lineBuf2[i] = param->kParam;
          }
-@@ -652,7 +652,7 @@
+@@ -652,7 +652,7 @@ int crxDecodeLineNoRefPrevLine(CrxBandParam *param)
          else if (param->kParam)
            bitCode = crxBitstreamGetBits(&param->bitStream, param->kParam) |
                      (bitCode << param->kParam);
@@ -45,7 +45,7 @@
          param->kParam = crxPredictKParameter(param->kParam, bitCode);
          if (param->lineBuf2[i + 1] - param->kParam <= 1)
          {
-@@ -743,7 +743,7 @@
+@@ -743,7 +743,7 @@ int crxDecodeTopLine(CrxBandParam *param)
      else if (param->kParam)
        bitCode = crxBitstreamGetBits(&param->bitStream, param->kParam) |
                  (bitCode << param->kParam);
@@ -54,7 +54,7 @@
      param->kParam = crxPredictKParameter(param->kParam, bitCode, 15);
      ++param->lineBuf1;
    }
-@@ -757,7 +757,7 @@
+@@ -757,7 +757,7 @@ int crxDecodeTopLine(CrxBandParam *param)
      else if (param->kParam)
        bitCode = crxBitstreamGetBits(&param->bitStream, param->kParam) |
                  (bitCode << param->kParam);
@@ -63,7 +63,7 @@
      param->kParam = crxPredictKParameter(param->kParam, bitCode, 15);
      ++param->lineBuf1;
    }
-@@ -830,7 +830,7 @@
+@@ -830,7 +830,7 @@ int crxDecodeTopLineRounded(CrxBandParam *param)
        bitCode = crxBitstreamGetBits(&param->bitStream, param->kParam) |
                  (bitCode << param->kParam);
  
@@ -72,7 +72,7 @@
      param->lineBuf1[1] += param->roundedBitsMask * 2 * sVal + (sVal >> 31);
      param->kParam = crxPredictKParameter(param->kParam, bitCode, 15);
      ++param->lineBuf1;
-@@ -844,7 +844,7 @@
+@@ -844,7 +844,7 @@ int crxDecodeTopLineRounded(CrxBandParam *param)
      else if (param->kParam)
        bitCode = crxBitstreamGetBits(&param->bitStream, param->kParam) |
                  (bitCode << param->kParam);
@@ -81,7 +81,7 @@
      param->lineBuf1[1] += param->roundedBitsMask * 2 * sVal + (sVal >> 31);
      param->kParam = crxPredictKParameter(param->kParam, bitCode, 15);
      ++param->lineBuf1;
-@@ -870,7 +870,7 @@
+@@ -870,7 +870,7 @@ int crxDecodeTopLineNoRefPrevLine(CrxBandParam *param)
        else if (param->kParam)
          bitCode = crxBitstreamGetBits(&param->bitStream, param->kParam) |
                    (bitCode << param->kParam);
@@ -90,7 +90,7 @@
        param->kParam = crxPredictKParameter(param->kParam, bitCode, 15);
      }
      else
-@@ -922,7 +922,7 @@
+@@ -922,7 +922,7 @@ int crxDecodeTopLineNoRefPrevLine(CrxBandParam *param)
        else if (param->kParam)
          bitCode = crxBitstreamGetBits(&param->bitStream, param->kParam) |
                    (bitCode << param->kParam);
@@ -99,7 +99,7 @@
        param->kParam = crxPredictKParameter(param->kParam, bitCode, 15);
      }
      param->lineBuf2[0] = param->kParam;
-@@ -938,7 +938,7 @@
+@@ -938,7 +938,7 @@ int crxDecodeTopLineNoRefPrevLine(CrxBandParam *param)
      else if (param->kParam)
        bitCode = crxBitstreamGetBits(&param->bitStream, param->kParam) |
                  (bitCode << param->kParam);
@@ -108,7 +108,7 @@
      param->kParam = crxPredictKParameter(param->kParam, bitCode, 15);
      param->lineBuf2[0] = param->kParam;
      ++param->lineBuf1;
-@@ -1085,7 +1085,7 @@
+@@ -1085,7 +1085,7 @@ int crxDecodeLineWithIQuantization(CrxSubband *subband)
            (bitCode << subband->paramK);
  
      subband->quantValue +=
@@ -117,87 +117,3 @@
      subband->paramK = crxPredictKParameter(subband->paramK, bitCode);
      if (subband->paramK > 7)
        return -1;
---- a/src/metadata/cr3_parser.cpp
-+++ b/src/metadata/cr3_parser.cpp
-@@ -298,7 +298,7 @@
-         AtomType = 1;
-       }
-       else
--        fseek(ifp, -lHdr, SEEK_CUR);
-+        fseek(ifp, 0u -lHdr, SEEK_CUR);
-     }
-     else if (!strcmp(AtomNameStack, "moovuuidCCTP"))
-     {
---- a/src/metadata/makernotes.cpp
-+++ b/src/metadata/makernotes.cpp
-@@ -96,7 +96,7 @@
- 
-   unsigned entries, tag, type, len, save, c;
- 
--  uchar *CanonCameraInfo;
-+  uchar *CanonCameraInfo = nullptr;
-   unsigned lenCanonCameraInfo = 0;
-   unsigned typeCanonCameraInfo = 0;
- 
-@@ -420,7 +420,7 @@
-   unsigned i, wb[4] = {0, 0, 0, 0};
-   short morder, sorder = order;
- 
--  uchar *CanonCameraInfo;
-+  uchar *CanonCameraInfo = nullptr;
-   unsigned lenCanonCameraInfo = 0;
-   unsigned typeCanonCameraInfo = 0;
-   imCanon.wbi = 0;
---- a/src/metadata/misc_parsers.cpp
-+++ b/src/metadata/misc_parsers.cpp
-@@ -71,7 +71,7 @@
-   int i, nz;
-   char tail[424];
- 
--  fseek(ifp, -sizeof tail, SEEK_END);
-+  fseek(ifp, 0u -sizeof tail, SEEK_END);
-   fread(tail, 1, sizeof tail, ifp);
-   for (nz = i = 0; i < int(sizeof tail); i++)
-     if (tail[i])
-@@ -102,7 +102,7 @@
-   width = get4();
-   height = get4();
-   fseek(ifp, 0, SEEK_END);
--  fseek(ifp, -(i = ftello(ifp) & 511), SEEK_CUR);
-+  fseek(ifp, 0u -(i = ftello(ifp) & 511), SEEK_CUR);
-   if (get4() != i || get4() != 0x52454f42)
-   {
-     fseek(ifp, 0, SEEK_SET);
---- a/src/metadata/nikon.cpp
-+++ b/src/metadata/nikon.cpp
-@@ -238,7 +238,7 @@
-   unsigned offset = 0, entries, tag, type, len, save;
- 
-   unsigned c, i;
--  uchar *LensData_buf;
-+  uchar *LensData_buf = nullptr;
-   uchar ColorBalanceData_buf[324];
-   int ColorBalanceData_ready = 0;
-   uchar ci, cj, ck;
---- a/src/metadata/pentax.cpp
-+++ b/src/metadata/pentax.cpp
-@@ -133,7 +133,7 @@
- void LibRaw::PentaxLensInfo(unsigned long long id, unsigned len) // tag 0x0207
- {
-   ushort iLensData = 0;
--  uchar *table_buf;
-+  uchar *table_buf = nullptr;
-   table_buf = (uchar *)malloc(MAX(len, 128));
-   fread(table_buf, len, 1, ifp);
-   if ((id < PentaxID_K100D) ||
---- a/src/metadata/sony.cpp
-+++ b/src/metadata/sony.cpp
-@@ -982,7 +982,7 @@
- {
- 
-   ushort lid, a, c, d;
--  uchar *table_buf;
-+  uchar *table_buf = nullptr;
-   uchar uc;
-   uchar s[2];
-   int LensDataValid = 0;

--- a/depends/windows/libraw/0004-fix-sdl-errors-2.patch
+++ b/depends/windows/libraw/0004-fix-sdl-errors-2.patch
@@ -1,0 +1,84 @@
+--- a/src/metadata/cr3_parser.cpp
++++ b/src/metadata/cr3_parser.cpp
+@@ -298,7 +298,7 @@ int LibRaw::parseCR3(unsigned long long oAtomList,
+         AtomType = 1;
+       }
+       else
+-        fseek(ifp, -lHdr, SEEK_CUR);
++        fseek(ifp, 0u -lHdr, SEEK_CUR);
+     }
+     else if (!strcmp(AtomNameStack, "moovuuidCCTP"))
+     {
+--- a/src/metadata/makernotes.cpp
++++ b/src/metadata/makernotes.cpp
+@@ -96,7 +96,7 @@ void LibRaw::parse_makernote_0xc634(int base, int uptag, unsigned dng_writer)
+ 
+   unsigned entries, tag, type, len, save, c;
+ 
+-  uchar *CanonCameraInfo;
++  uchar *CanonCameraInfo = nullptr;
+   unsigned lenCanonCameraInfo = 0;
+   unsigned typeCanonCameraInfo = 0;
+ 
+@@ -420,7 +420,7 @@ void LibRaw::parse_makernote(int base, int uptag)
+   unsigned i, wb[4] = {0, 0, 0, 0};
+   short morder, sorder = order;
+ 
+-  uchar *CanonCameraInfo;
++  uchar *CanonCameraInfo = nullptr;
+   unsigned lenCanonCameraInfo = 0;
+   unsigned typeCanonCameraInfo = 0;
+   imCanon.wbi = 0;
+--- a/src/metadata/misc_parsers.cpp
++++ b/src/metadata/misc_parsers.cpp
+@@ -71,7 +71,7 @@ int LibRaw::minolta_z2()
+   int i, nz;
+   char tail[424];
+ 
+-  fseek(ifp, -sizeof tail, SEEK_END);
++  fseek(ifp, 0u -sizeof tail, SEEK_END);
+   fread(tail, 1, sizeof tail, ifp);
+   for (nz = i = 0; i < int(sizeof tail); i++)
+     if (tail[i])
+@@ -102,7 +102,7 @@ void LibRaw::parse_redcine()
+   width = get4();
+   height = get4();
+   fseek(ifp, 0, SEEK_END);
+-  fseek(ifp, -(i = ftello(ifp) & 511), SEEK_CUR);
++  fseek(ifp, 0u -(i = ftello(ifp) & 511), SEEK_CUR);
+   if (get4() != i || get4() != 0x52454f42)
+   {
+     fseek(ifp, 0, SEEK_SET);
+--- a/src/metadata/nikon.cpp
++++ b/src/metadata/nikon.cpp
+@@ -238,7 +238,7 @@ void LibRaw::parseNikonMakernote(int base, int uptag, unsigned dng_writer)
+   unsigned offset = 0, entries, tag, type, len, save;
+ 
+   unsigned c, i;
+-  uchar *LensData_buf;
++  uchar *LensData_buf = nullptr;
+   uchar ColorBalanceData_buf[324];
+   int ColorBalanceData_ready = 0;
+   uchar ci, cj, ck;
+--- a/src/metadata/pentax.cpp
++++ b/src/metadata/pentax.cpp
+@@ -133,7 +133,7 @@ void LibRaw::PentaxISO(ushort c)
+ void LibRaw::PentaxLensInfo(unsigned long long id, unsigned len) // tag 0x0207
+ {
+   ushort iLensData = 0;
+-  uchar *table_buf;
++  uchar *table_buf = nullptr;
+   table_buf = (uchar *)malloc(MAX(len, 128));
+   fread(table_buf, len, 1, ifp);
+   if ((id < PentaxID_K100D) ||
+--- a/src/metadata/sony.cpp
++++ b/src/metadata/sony.cpp
+@@ -982,7 +982,7 @@ void LibRaw::parseSonyMakernotes(
+ {
+ 
+   ushort lid, a, c, d;
+-  uchar *table_buf;
++  uchar *table_buf = nullptr;
+   uchar uc;
+   uchar s[2];
+   int LensDataValid = 0;


### PR DESCRIPTION
This fails to build in UWP due libraw patches contains discrepancies in line endings (mixed \r\n and \n terminations):

```
[ 66%] Performing patch step for 'libraw'
patching file cmake/libraw-config.cmake
patching file src/libraw_datastream.cpp
Hunk #1 succeeded at 644 with fuzz 2 (offset -43 lines).
patching file src/decoders/crx.cpp
Hunk #1 FAILED at 347 (different line endings).
Hunk #2 FAILED at 456 (different line endings).
Hunk #3 FAILED at 576 (different line endings).
Hunk #4 FAILED at 638 (different line endings).
Hunk #5 FAILED at 652 (different line endings).
Hunk #6 FAILED at 743 (different line endings).
Hunk #7 FAILED at 757 (different line endings).
Hunk #8 FAILED at 830 (different line endings).
Hunk #9 FAILED at 844 (different line endings).
Hunk #10 FAILED at 870 (different line endings).
Hunk #11 FAILED at 922 (different line endings).
Hunk #12 FAILED at 938 (different line endings).
Hunk #13 FAILED at 1085 (different line endings).
13 out of 13 hunks FAILED -- saving rejects to file src/decoders/crx.cpp.rej
```

It's not really that the patches are wrong but that the source files are not consistent and have different line endings. This is hard to handle by patch.exe so I've split the patch `0003-fix-sdl-errors.patch` into two: 

`0003-fix-sdl-errors.patch`  ---> contains only \r\n endings
`0004-fix-sdl-errors-2.patch` ----> contains only \n endings

Also `0002-fix-uwp-api.patch` only updated to apply clean.

NOTE: The Windows x64 build works in Jenkins because it uses an older version of patch.exe that supports this (it's not patch.exe that ships with Git). I mean it works by chance.

Tested locally using patch.exe of Git.

Also note that the core cmake scripts have been updated by https://github.com/xbmc/xbmc/pull/21377 to give preference to using Git's patch.exe, so it is likely that from now this addon will stop compiling on Windows x64 without this PR.
